### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/samkeen/llm-api-adapter/compare/v0.1.2...v0.2.0) - 2024-04-19
+
+### Other
+- Swithed to builder pattern for send_message
+- added `first_message` fn to `ResponseMessage`
+
 ## [0.1.2](https://github.com/samkeen/llm-api-adapter/compare/v0.1.1...v0.1.2) - 2024-04-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "llm-api-adapter"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "dotenv",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-api-adapter"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Sam Keen <sam.sjk@gmail.com>"]
 description = "SDK for interacting with various Large Language Model (LLM) APIs"


### PR DESCRIPTION
## 🤖 New release
* `llm-api-adapter`: 0.1.2 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `llm-api-adapter` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RequestBody.system in /tmp/.tmpMbz4fN/llm-api-adapter/src/models.rs:36

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_variant_added.ron

Failed in:
  variant ApiError:MissingMessages in /tmp/.tmpMbz4fN/llm-api-adapter/src/error.rs:18

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/inherent_method_missing.ron

Failed in:
  AnthropicClient::send_message, previously in file /tmp/.tmpEIP6F7/llm-api-adapter/src/client.rs:34

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/method_parameter_count_changed.ron

Failed in:
  llm_api_adapter::client::AnthropicClient::chat now takes 5 parameters instead of 4, in /tmp/.tmpMbz4fN/llm-api-adapter/src/client.rs:177
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/samkeen/llm-api-adapter/compare/v0.1.2...v0.2.0) - 2024-04-19

### Other
- Swithed to builder pattern for send_message
- added `first_message` fn to `ResponseMessage`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).